### PR TITLE
Get doodads

### DIFF
--- a/sandbox-server/app.js
+++ b/sandbox-server/app.js
@@ -1,9 +1,21 @@
 const express = require('express')
+const bodyParser = require('body-parser')
 const app = express()
+
+app.use(bodyParser.urlencoded({ extended: false }))
 
 app.get('/', (request, response) => {
   response.type('text/plain')
   response.send('Welcome to Sandbox!')
+})
+
+app.get('/search', (request, response) => {
+  response.type('text/plain')
+  if(request.query.hasOwnProperty('q') && request.query.q === 'doodads') {
+    response.send('You searched for: "doodads"')
+  } else {
+    response.send('Your search isn\'t part of the spec')
+  }
 })
 
 app.listen(3000)


### PR DESCRIPTION
Includes get-index history

this website [here](http://stackoverflow.com/questions/40582895/status-code-304-jade-node-express) explains why we're getting 304 responses when refreshing, and that we don't actually want to override it, but rather keep it just as is.

For now, hard-refresh to get the proper response. (Or postman?)
