### PR TITLE
Get old page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@
   - [X] a 200 (OK) status code
   - [X] an HTML response body with the content `<!DOCTYPE html><html><body>This is an HTML file</body></html>`
   - [X] the `Content-Type` header set to `text/html`
-- [ ] Sending a `GET` request to the path `/myjsondata` with an `Accept` header of `application/json` responds with...
-  - [ ] a 200 (OK) status code
-  - [ ] an HTML response body with the content `{ "title": "some JSON data" }`
-  - [ ] the `Content-Type` header set to `application/json`
+- [X] Sending a `GET` request to the path `/myjsondata` with an `Accept` header of `application/json` responds with...
+  - [X] a 200 (OK) status code
+  - [X] an HTML response body with the content `{ "title": "some JSON data" }`
+  - [X] the `Content-Type` header set to `application/json`
 - [ ] Sending a `GET` request to the path `/old-page` responds with...
   - [ ] a 301 (Moved Permanently) status code
   - [ ] the `Location` header set to `http://localhost:3000/newpage`

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
   - [X] a 200 (OK) status code
   - [X] an HTML response body with the content `{ "title": "some JSON data" }`
   - [X] the `Content-Type` header set to `application/json`
-- [ ] Sending a `GET` request to the path `/old-page` responds with...
-  - [ ] a 301 (Moved Permanently) status code
-  - [ ] the `Location` header set to `http://localhost:3000/newpage`
+- [X] Sending a `GET` request to the path `/old-page` responds with...
+  - [X] a 301 (Moved Permanently) status code
+  - [X] the `Location` header set to `http://localhost:3000/newpage`
 - [ ] Sending a `POST` request to the path `/admin-only` responds with a 403 (Forbidden) status code
 - [ ] Sending a `GET` request to the path `/not-a-page` responds with a 404 (Not Found) status code
 - [ ] Sending a `GET` request to the path `/server-error` responds with a 500 (Internal Server Error) staus code

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@
   - [X] a 400 (Bad Request) status code
   - [X] a plain-text response body with the content `You didn't provide a search query term :(`
   - [X] the `Content-Type` header set to `text/plain`
-- [ ] Sending a `POST` request to the path `/things` with a plain text body `flying car` responds with...
-  - [ ] a 201 (Created) status code
-  - [ ] a plain-text response body with the content `New thing created: "flying car"!` (it doesn't need to actually create anything, just return the plain text)
-  - [ ] the `Content-Type` header set to `text/plain`
-- [ ] Sending a `GET` request to the path `/somefile` with an `Accept` header of `text/plain` responds with...
-  - [ ] a 200 (OK) status code
-  - [ ] a plain-text response body with the content `This is a plain text file`
-  - [ ] the `Content-Type` header set to `text/plain`
+- [X] Sending a `POST` request to the path `/things` with a plain text body `flying car` responds with...
+  - [X] a 201 (Created) status code
+  - [X] a plain-text response body with the content `New thing created: "flying car"!` (it doesn't need to actually create anything, just return the plain text)
+  - [X] the `Content-Type` header set to `text/plain`
+- [X] Sending a `GET` request to the path `/somefile` with an `Accept` header of `text/plain` responds with...
+  - [X] a 200 (OK) status code
+  - [X] a plain-text response body with the content `This is a plain text file`
+  - [X] the `Content-Type` header set to `text/plain`
 - [ ] Sending a `GET` request to the path `/somefile` with an `Accept` header of `text/html` responds with...
   - [ ] a 200 (OK) status code
   - [ ] an HTML response body with the content `<!DOCTYPE html><html><body>This is an HTML file</body></html>`

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@
   - [X] a 200 (OK) status code
   - [X] a plain-text response body with the content `This is a plain text file`
   - [X] the `Content-Type` header set to `text/plain`
-- [ ] Sending a `GET` request to the path `/somefile` with an `Accept` header of `text/html` responds with...
-  - [ ] a 200 (OK) status code
-  - [ ] an HTML response body with the content `<!DOCTYPE html><html><body>This is an HTML file</body></html>`
-  - [ ] the `Content-Type` header set to `text/html`
+- [X] Sending a `GET` request to the path `/somefile` with an `Accept` header of `text/html` responds with...
+  - [X] a 200 (OK) status code
+  - [X] an HTML response body with the content `<!DOCTYPE html><html><body>This is an HTML file</body></html>`
+  - [X] the `Content-Type` header set to `text/html`
 - [ ] Sending a `GET` request to the path `/myjsondata` with an `Accept` header of `application/json` responds with...
   - [ ] a 200 (OK) status code
   - [ ] an HTML response body with the content `{ "title": "some JSON data" }`

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@
 - [X] Sending a `GET` request to the path `/old-page` responds with...
   - [X] a 301 (Moved Permanently) status code
   - [X] the `Location` header set to `http://localhost:3000/newpage`
-- [ ] Sending a `POST` request to the path `/admin-only` responds with a 403 (Forbidden) status code
-- [ ] Sending a `GET` request to the path `/not-a-page` responds with a 404 (Not Found) status code
-- [ ] Sending a `GET` request to the path `/server-error` responds with a 500 (Internal Server Error) staus code
+- [X] Sending a `POST` request to the path `/admin-only` responds with a 403 (Forbidden) status code
+- [X] Sending a `GET` request to the path `/not-a-page` responds with a 404 (Not Found) status code
+- [X] Sending a `GET` request to the path `/server-error` responds with a 500 (Internal Server Error) staus code
 
 **Postalicious**
 

--- a/sandbox-server/app.js
+++ b/sandbox-server/app.js
@@ -30,6 +30,10 @@ app.get('/somefile', (request, response) => {
     response.type('text/plain')
     response.status(200)
     response.send('This is a plain text file')
+  } else if( request.accepts('text/html')) {
+    response.type('text/html')
+    response.status(200)
+    response.send('<!DOCTYPE html><html><body>This is an HTML file</body></html>')
   }
 })
 

--- a/sandbox-server/app.js
+++ b/sandbox-server/app.js
@@ -26,18 +26,28 @@ app.post('/things', (request, response) => {
 })
 
 app.get('/somefile', (request, response) => {
-  if ( request.accepts('text/plain')) {
-    response.type('text/plain')
-    response.status(200)
-    response.send('This is a plain text file')
-  } else if( request.accepts('text/html')) {
-    response.type('text/html')
-    response.status(200)
-    response.send('<!DOCTYPE html><html><body>This is an HTML file</body></html>')
-  } else {
-    response.type('application/json')
-    response.status(200)
-    response.json({ "title": "some JSON data" })
+  response.status(200)
+  let requestAcceptTypes = {
+    'text/plain': {
+      'method': 'send',
+      'responseMessage': 'This is a plain text file'
+    },
+    'text/html': {
+      'method': 'send',
+      'responseMessage': '<!DOCTYPE html><html><body>This is an HTML file</body></html>'
+    },
+    'application/json': {
+      'method': 'json',
+      'responseMessage': { "title": "some JSON data" }
+    }
+  }
+
+  for( let acceptType in requestAcceptTypes ) {
+    let values = requestAcceptTypes[acceptType]
+    if(request.accepts(acceptType)) {
+      response.type(acceptType)
+      response[values.method](values.responseMessage)
+    }
   }
 })
 

--- a/sandbox-server/app.js
+++ b/sandbox-server/app.js
@@ -51,4 +51,10 @@ app.get('/somefile', (request, response) => {
   }
 })
 
+app.get('/old-page', (request, response) => {
+  response.status(301)
+  response.setHeader( 'Location', 'http://localhost:3000/newpage')
+  response.send()
+})
+
 app.listen(3000)

--- a/sandbox-server/app.js
+++ b/sandbox-server/app.js
@@ -25,4 +25,12 @@ app.post('/things', (request, response) => {
   response.send('New thing created: '+request.body)
 })
 
+app.get('/somefile', (request, response) => {
+  if ( request.accepts('text/plain')) {
+    response.type('text/plain')
+    response.status(200)
+    response.send('This is a plain text file')
+  }
+})
+
 app.listen(3000)

--- a/sandbox-server/app.js
+++ b/sandbox-server/app.js
@@ -57,4 +57,16 @@ app.get('/old-page', (request, response) => {
   response.send()
 })
 
+app.post('/admin-only', (request, response) => {
+  response.sendStatus(403)
+})
+
+app.get('/not-a-page', (request, response) => {
+  response.sendStatus(404)
+})
+
+app.get('/server-error', (request, response) => {
+  response.sendStatus(500)
+})
+
 app.listen(3000)

--- a/sandbox-server/app.js
+++ b/sandbox-server/app.js
@@ -34,6 +34,10 @@ app.get('/somefile', (request, response) => {
     response.type('text/html')
     response.status(200)
     response.send('<!DOCTYPE html><html><body>This is an HTML file</body></html>')
+  } else {
+    response.type('application/json')
+    response.status(200)
+    response.json({ "title": "some JSON data" })
   }
 })
 


### PR DESCRIPTION
When opening pages from a localhost server, the browser opens up a cached version of the page as indicated by the size column for (network items? What are these called?) of the network tab, instead of making a new request for the object from the server. Incognito mode does not prevent this behavior. Hard-refresh will allow for a new request, but for links that redirect, one cannot pause execution long enough to perform the hard-refresh. How should we resolve this issue?